### PR TITLE
feat: Add streaming cancellation to chat UI and backend

### DIFF
--- a/src/main/resources/ui/chat_view.fxml
+++ b/src/main/resources/ui/chat_view.fxml
@@ -83,7 +83,10 @@
                           
                           <javafx.scene.control.ComboBox fx:id="modelSelector" promptText="%chat.selectModel" styleClass="capsule-combo-box" prefWidth="150.0" />
                           
-                          <Button fx:id="sendButton" onAction="#sendMessage" styleClass="send-button-icon" text="➤" />
+                          <javafx.scene.layout.StackPane alignment="CENTER_RIGHT">
+                              <Button fx:id="sendButton" onAction="#sendMessage" styleClass="send-button-icon" text="➤" />
+                              <Button fx:id="cancelButton" onAction="#onCancelClicked" styleClass="send-button-icon" text="⏹" visible="false" managed="false" style="-fx-text-fill: white; -fx-font-size: 16px; -fx-background-color: #ff4444;" />
+                          </javafx.scene.layout.StackPane>
                       </children>
                   </HBox>
                </children>


### PR DESCRIPTION
Introduces a cancel button to the chat UI for interrupting ongoing model generation. Implements cancellation logic in ChatController and OllamaManager, allowing users to stop streaming responses mid-generation. The UI now toggles between send and cancel buttons, and backend forcibly closes active HTTP streams for prompt cancellation.