### PR TITLE
feat: Add Ollama service status bar and manager

### DIFF
--- a/src/main/java/com/org/ollamafx/manager/OllamaServiceManager.java
+++ b/src/main/java/com/org/ollamafx/manager/OllamaServiceManager.java
@@ -1,0 +1,113 @@
+package com.org.ollamafx.manager;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+public class OllamaServiceManager {
+
+    private static OllamaServiceManager instance;
+    private Process ollamaProcess;
+
+    private OllamaServiceManager() {
+    }
+
+    public static OllamaServiceManager getInstance() {
+        if (instance == null) {
+            instance = new OllamaServiceManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Checks if Ollama CLI is installed and accessible in the system PATH.
+     */
+    public boolean isInstalled() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("ollama", "--version");
+            Process p = pb.start();
+            boolean finished = p.waitFor(5, TimeUnit.SECONDS);
+            return finished && p.exitValue() == 0;
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if the Ollama service is currently running on the default port
+     * (11434).
+     */
+    public boolean isRunning() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", 11434), 500); // 500ms timeout
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to start the Ollama service.
+     */
+    public boolean startOllama() {
+        if (isRunning())
+            return true;
+
+        System.out.println("OllamaServiceManager: Attempting to start Ollama...");
+        try {
+            ProcessBuilder pb = new ProcessBuilder("ollama", "serve");
+            // Redirect output to inherit IO so we can see logs if run from terminal,
+            // or maybe redirect to a specific log file in the future.
+            // For now, let's keep it simple.
+            pb.redirectErrorStream(true);
+
+            this.ollamaProcess = pb.start();
+
+            // Give it a moment to spin up
+            int Retries = 10;
+            while (Retries > 0) {
+                Thread.sleep(1000);
+                if (isRunning()) {
+                    System.out.println("OllamaServiceManager: Ollama started successfully.");
+                    return true;
+                }
+                Retries--;
+            }
+            return false; // Timed out
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to stop the locally managed Ollama process.
+     * Note: This only works if WE started it. Stopping a system-wide service is
+     * harder/requires admin.
+     * However, the requirement is "Start/Stop" button.
+     * If we didn't start it, we can't easily kill it without 'pkill' which might be
+     * aggressive.
+     * Let's try to kill the process we hold reference to first.
+     */
+    public void stopOllama() {
+        if (this.ollamaProcess != null && this.ollamaProcess.isAlive()) {
+            System.out.println("OllamaServiceManager: Stopping local Ollama process...");
+            this.ollamaProcess.destroy(); // SIGTERM
+        } else {
+            // Try explicit kill if we want to be aggressive (User request: "botón para
+            // iniciar o apagar")
+            // This is useful if the user started it manually or via another instance.
+            // On Mac/Linux:
+            try {
+                System.out.println("OllamaServiceManager: Attempting to kill system ollama process...");
+                ProcessBuilder pb = new ProcessBuilder("pkill", "ollama");
+                pb.start().waitFor();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/resources/css/ollama_active.css
+++ b/src/main/resources/css/ollama_active.css
@@ -467,7 +467,197 @@
     -fx-background-color: transparent;
 }
 
-.body-large {
+
+
+/* --- NANO BANANA (LIGHT INTEGRATED) --- */
+.status-bar-nano {
+    -fx-background-color: transparent;
+    /* Seamless with sidebar */
+    -fx-border-color: -color-border-subtle;
+    -fx-border-width: 1px 0 0 0;
+}
+
+.status-dot-nano {
+    -fx-fill: -color-border-subtle;
+    /* Default off/loading */
+}
+
+.status-dot-running {
+    -fx-fill: #34c759;
+    /* iOS Green (Screenshot match) */
+    -fx-effect: dropshadow(gaussian, rgba(52, 199, 89, 0.3), 8, 0, 0, 0);
+}
+
+.status-dot-stopped {
+    -fx-fill: #8e8e93;
+    /* IOS Grey (Inactive) or Red if error */
+    /* Screenshot shows green when running. Assuming grey/neutral when off or red if error.
+       Let's stick to neutral grey for "stopped" to be clean like macOS. */
+}
+
+.status-label-nano {
+    -fx-font-family: system;
+    -fx-font-size: 11px;
+    -fx-text-fill: -color-fg-default;
+    /* Dark text */
+    -fx-font-weight: normal;
+}
+
+.status-latency-nano {
+    -fx-font-family: "Monospaced";
+    -fx-font-size: 10px;
+    -fx-text-fill: rgba(255, 255, 255, 0.5);
+}
+
+/* Toggle Switch Nano (Red/Green) */
+.toggle-switch-nano {
+    -fx-background-color: #ff3b30, white;
+    /* Red (Off) Track, White Knob */
+    -fx-background-insets: 0, 2 18 2 2;
+    /* Knob on Left (for Off state approx) - wait, width is 36. 
+                                           Knob size ~16. 
+                                           Insets: Top=2, Right=18, Bottom=2, Left=2. 
+                                           Right inset 18 means 36-18 = 18px from right. 
+                                           Knob width = 36 - 2 - 18 = 16. Correct. */
+    -fx-background-radius: 20, 20;
+    -fx-text-fill: transparent;
+    -fx-padding: 0;
+    /* Clear padding, use insets for graphic */
+    -fx-cursor: hand;
+    -fx-min-width: 36px;
+    -fx-max-width: 36px;
+    -fx-min-height: 20px;
+    -fx-max-height: 20px;
+}
+
+.toggle-switch-nano:selected {
+    -fx-background-color: #34c759, white;
+    /* Green (On) Track, White Knob */
+    -fx-background-insets: 0, 2 2 2 18;
+    /* Knob on Right.
+                                           Insets: Top=2, Right=2, Bottom=2, Left=18. */
+}
+
+.toggle-switch-nano:hover {
+    -fx-opacity: 0.9;
+}
+
+/* --- FULL WIDTH COLOR OLLAMA STATUS BAR --- */
+.status-bar-container {
+    -fx-padding: 12px 15px;
+    -fx-background-radius: 0;
+}
+
+/* Background Colors */
+.status-bar-stopped {
+    -fx-background-color: #d32f2f;
+    /* Muted Red (Material Red 700) - "Dry Red" */
+}
+
+.status-bar-running {
+    -fx-background-color: #388e3c;
+    /* Muted Green (Material Green 700) - "Dry Green" */
+}
+
+.status-label-white {
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-font-size: 13px;
+}
+
+/* SWITCH BUTTON STYLING */
+.status-switch-button {
+    -fx-background-color: white;
+    -fx-text-fill: -color-fg-default;
+    -fx-background-radius: 15px;
+    /* Pill shape */
+    -fx-min-width: 50px;
+    -fx-padding: 3px 10px;
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+    -fx-cursor: hand;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.2), 3, 0, 0, 1);
+}
+
+.status-switch-button:selected {
+    -fx-background-color: white;
+    /* Keep white bg for the "knob" look if possible, or inverse */
+    -fx-text-fill: #388e3c;
+}
+
+
+/* Make it look more like a switch? 
+   Actually, standard ToggleButton with pills style is clean. 
+   User asked for "boton switch" shape.
+   Let's simulate a simpler toggle: White pill with text inside.
+*/
+
+/* --- REFINED OLLAMA STATUS BAR --- */
+.status-bar-refined {
+    -fx-padding: 10px 15px;
+    -fx-background-color: rgba(0, 0, 0, 0.03);
+    /* Subtle footer background */
+    -fx-border-color: -color-border-subtle;
+    -fx-border-width: 1px 0 0 0;
+}
+
+.status-indicator-dot {
+    -fx-min-width: 8px;
+    -fx-min-height: 8px;
+    -fx-max-width: 8px;
+    -fx-max-height: 8px;
+    -fx-background-radius: 5px;
+}
+
+/* Re-use active/inactive classes but with updated colors if needed */
+.status-dot-active {
+    -fx-background-color: #34c759;
+    /* iOS Green */
+    -fx-effect: dropshadow(gaussian, rgba(52, 199, 89, 0.4), 6, 0, 0, 0);
+}
+
+.status-dot-inactive {
+    -fx-background-color: #ff3b30;
+    /* iOS Red */
+}
+
+.status-title-small {
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+    -fx-text-fill: -color-fg-default;
+}
+
+.status-subtitle-small {
+    -fx-font-size: 10px;
+    -fx-text-fill: -color-fg-muted;
+}
+
+/* POWER BUTTON */
+.icon-button-power {
+    -fx-background-color: transparent;
+    -fx-padding: 5px;
+    -fx-cursor: hand;
+    -fx-border-radius: 50%;
+    -fx-background-radius: 50%;
+}
+
+.icon-button-power:hover {
+    -fx-background-color: rgba(0, 0, 0, 0.05);
+}
+
+.icon-button-power:pressed {
+    -fx-background-color: rgba(0, 0, 0, 0.1);
+}
+
+.power-icon-shape {
+    -fx-fill: -color-fg-muted;
+    /* Default Grey */
+    -fx-min-width: 16px;
+    -fx-min-height: 16px;
+    -fx-scale-x: 0.9;
+    -fx-scale-y: 0.9;
+}
+
+.icon-button-power:hover .power-icon-shape {
     -fx-fill: -color-fg-default;
-    -fx-font-size: 14px;
 }

--- a/src/main/resources/ui/main_view.fxml
+++ b/src/main/resources/ui/main_view.fxml
@@ -78,6 +78,33 @@
                         <Insets bottom="10.0" left="5.0" right="5.0" top="5.0" />
                     </padding>
                 </VBox>
+                
+                <!-- OLLAMA STATUS BAR (Refined) -->
+                <!-- OLLAMA STATUS BAR (Full Width Color) -->
+                <!-- OLLAMA STATUS BAR (Nano Banana - Minimalist Pulse) -->
+                <HBox fx:id="ollamaStatusBar" styleClass="status-bar-nano" alignment="CENTER_LEFT" spacing="12.0">
+                     <children>
+                         <!-- Pulse Dot -->
+                         <javafx.scene.layout.StackPane>
+                             <javafx.scene.shape.Circle fx:id="pulseEmitter" radius="6.0" styleClass="pulse-emitter" opacity="0.0"/>
+                             <javafx.scene.shape.Circle fx:id="statusDot" radius="4.0" styleClass="status-dot-nano" />
+                         </javafx.scene.layout.StackPane>
+                         
+                         <!-- Status Text -->
+                         <Label fx:id="statusLabel" text="System Operational" styleClass="status-label-nano" />
+                         
+                         <javafx.scene.layout.Region HBox.hgrow="ALWAYS" />
+
+                         <!-- Controls -->
+                         <HBox alignment="CENTER_RIGHT" spacing="15.0">
+                             <!-- Subtle Switch -->
+                             <javafx.scene.control.ToggleButton fx:id="btnControlOllama" text="" onAction="#toggleOllamaService" styleClass="toggle-switch-nano" />
+                         </HBox>
+                     </children>
+                     <padding>
+                        <Insets top="15.0" bottom="15.0" left="20.0" right="20.0"/>
+                     </padding>
+                </HBox>
             </children>
         </VBox>
     </left>


### PR DESCRIPTION
Introduces a new OllamaServiceManager class to control and monitor the Ollama service (start/stop/status). Updates MainController and main_view.fxml to display a status bar with live service status, a pulse animation, and a toggle button for starting/stopping the service. Also refines related CSS for the status bar and switch appearance. ChatController now dynamically updates model selectors when models change.