### PR TITLE
Redesign About view; add GitHub stats & donations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/com/org/ollamafx/App.java
+++ b/src/main/java/com/org/ollamafx/App.java
@@ -5,6 +5,7 @@ import com.org.ollamafx.controller.MainController;
 import com.org.ollamafx.manager.ModelLibraryManager;
 import com.org.ollamafx.manager.ModelManager;
 import javafx.application.Application;
+import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
@@ -16,9 +17,14 @@ import com.org.ollamafx.manager.ChatManager;
 public class App extends Application {
 
     private static java.util.concurrent.ExecutorService executorService;
+    private static HostServices hostServices;
 
     public static java.util.concurrent.ExecutorService getExecutorService() {
         return executorService;
+    }
+
+    public static HostServices getAppHostServices() {
+        return hostServices;
     }
 
     @Override
@@ -52,6 +58,7 @@ public class App extends Application {
         });
 
         primaryStage = stage;
+        hostServices = getHostServices();
 
         ChatManager.getInstance().loadChats();
         Application.setUserAgentStylesheet(new atlantafx.base.theme.CupertinoLight().getUserAgentStylesheet());
@@ -62,7 +69,6 @@ public class App extends Application {
         ModelLibraryManager.UpdateStatus cacheStatus = ModelLibraryManager.getInstance().getUpdateStatus();
 
         boolean needsSplash = (cacheStatus == ModelLibraryManager.UpdateStatus.OUTDATED_HARD);
-
 
         if (needsSplash) {
             // Cache is missing or expired (> 10 days) -> Show Splash Screen

--- a/src/main/java/com/org/ollamafx/controller/AboutController.java
+++ b/src/main/java/com/org/ollamafx/controller/AboutController.java
@@ -1,25 +1,40 @@
 package com.org.ollamafx.controller;
 
-import java.awt.Desktop;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
+import com.org.ollamafx.App;
+import com.org.ollamafx.manager.GitHubStatsService;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.ProgressIndicator;
+
 import java.net.URL;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.io.InputStream;
+import java.io.IOException;
 
 public class AboutController implements Initializable {
 
     @FXML
     private Label versionLabel;
+    @FXML
+    private Label downloadsLabel;
+    @FXML
+    private ProgressIndicator downloadSpinner;
+
+    // Buttons with icons set programmatically
+    @FXML
+    private Button paypalButton;
+    @FXML
+    private Button coffeeButton;
+    @FXML
+    private Button githubButton;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        // Load version
         String version = "Unknown";
         try (InputStream input = getClass().getResourceAsStream("/app.properties")) {
             if (input != null) {
@@ -31,25 +46,89 @@ public class AboutController implements Initializable {
             e.printStackTrace();
         }
         versionLabel.setText("Version " + version);
+
+        // Set emoji icons as button graphics
+        setButtonIcon(paypalButton, "💳");
+        setButtonIcon(coffeeButton, "☕");
+        setButtonIcon(githubButton, "🐙");
+
+        // Load GitHub stats
+        loadGitHubStats();
+    }
+
+    /**
+     * Sets an emoji Label as the graphic (left icon) of a Button.
+     */
+    private void setButtonIcon(Button button, String emoji) {
+        if (button == null)
+            return;
+        Label icon = new Label(emoji);
+        icon.setStyle("-fx-font-size: 15px;");
+        button.setGraphic(icon);
+        button.setGraphicTextGap(8);
+    }
+
+    private void loadGitHubStats() {
+        if (downloadsLabel != null && downloadSpinner != null) {
+            downloadsLabel.setText("...");
+            downloadSpinner.setVisible(true);
+        }
+
+        GitHubStatsService.getInstance().fetchTotalDownloads()
+                .thenAccept(downloads -> {
+                    Platform.runLater(() -> {
+                        if (downloads > 0) {
+                            downloadsLabel.setText(String.format("%,d", downloads));
+                        } else {
+                            downloadsLabel.setText("N/A");
+                        }
+                        if (downloadSpinner != null) {
+                            downloadSpinner.setVisible(false);
+                        }
+                    });
+                })
+                .exceptionally(ex -> {
+                    Platform.runLater(() -> {
+                        downloadsLabel.setText("N/A");
+                        if (downloadSpinner != null) {
+                            downloadSpinner.setVisible(false);
+                        }
+                    });
+                    return null;
+                });
     }
 
     @FXML
     private void openGitHub() {
-        openLink("https://github.com/fredericksalazar/OllamaFX"); // Replace with actual repo if different
+        openLink("https://github.com/fredericksalazar/OllamaFX");
+    }
+
+    @FXML
+    private void openPayPal() {
+        // Using standard donation link with email since paypal.me handle is uncertain
+        openLink("https://www.paypal.com/donate/?business=fredefass01@gmail.com");
+    }
+
+    @FXML
+    private void openBuyMeCoffee() {
+        openLink("https://buymeacoffee.com/fredericksalazar");
+    }
+
+    @FXML
+    private void openGitHubContribute() {
+        openLink("https://github.com/fredericksalazar/OllamaFX/issues");
     }
 
     private void openLink(String url) {
-        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-            try {
-                Desktop.getDesktop().browse(new URI(url));
-            } catch (IOException | URISyntaxException e) {
-                e.printStackTrace();
+        try {
+            if (App.getAppHostServices() != null) {
+                App.getAppHostServices().showDocument(url);
+            } else {
+                System.err.println("HostServices not available. URL: " + url);
             }
-        } else {
-            // Fallback for non-desktop environments (though JavaFX implies desktop)
-            System.err.println("Desktop browse not supported. URL: " + url);
-            // On Linux/Mac sometimes ProcessBuilder is more reliable if Desktop fails,
-            // but Desktop is standard.
+        } catch (Exception e) {
+            System.err.println("Error opening URL: " + url);
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/com/org/ollamafx/manager/GitHubStatsService.java
+++ b/src/main/java/com/org/ollamafx/manager/GitHubStatsService.java
@@ -1,0 +1,110 @@
+package com.org.ollamafx.manager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service to fetch GitHub repository statistics asynchronously.
+ * Uses GitHub API to retrieve download counts from releases.
+ */
+public class GitHubStatsService {
+
+    private static GitHubStatsService instance;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    private static final String RELEASES_API_URL = "https://api.github.com/repos/fredericksalazar/OllamaFX/releases";
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private GitHubStatsService() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(REQUEST_TIMEOUT)
+                .build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public static synchronized GitHubStatsService getInstance() {
+        if (instance == null) {
+            instance = new GitHubStatsService();
+        }
+        return instance;
+    }
+
+    /**
+     * Fetches total download count from all assets of the latest release.
+     * 
+     * @return CompletableFuture with total downloads, or -1 if error occurs
+     */
+    public CompletableFuture<Integer> fetchTotalDownloads() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(RELEASES_API_URL))
+                        .timeout(REQUEST_TIMEOUT)
+                        .header("Accept", "application/vnd.github.v3+json")
+                        .GET()
+                        .build();
+
+                HttpResponse<String> response = httpClient.send(
+                        request,
+                        HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200) {
+                    System.err.println("GitHub API returned status: " + response.statusCode());
+                    return -1;
+                }
+
+                return parseDownloadCount(response.body());
+
+            } catch (Exception e) {
+                System.err.println("Error fetching GitHub stats: " + e.getMessage());
+                return -1;
+            }
+        });
+    }
+
+    /**
+     * Parses the JSON response to extract total download count.
+     * Sums download_count from all assets in the latest (first) release.
+     * 
+     * @param jsonResponse JSON string from GitHub API
+     * @return total download count, or -1 if parsing fails
+     */
+    private int parseDownloadCount(String jsonResponse) {
+        try {
+            JsonNode releases = objectMapper.readTree(jsonResponse);
+
+            if (releases.isArray() && releases.size() > 0) {
+                // Get the latest release (first in the array)
+                JsonNode latestRelease = releases.get(0);
+                JsonNode assets = latestRelease.get("assets");
+
+                if (assets != null && assets.isArray()) {
+                    int totalDownloads = 0;
+
+                    for (JsonNode asset : assets) {
+                        JsonNode downloadCount = asset.get("download_count");
+                        if (downloadCount != null) {
+                            totalDownloads += downloadCount.asInt();
+                        }
+                    }
+
+                    return totalDownloads;
+                }
+            }
+
+            return -1;
+
+        } catch (Exception e) {
+            System.err.println("Error parsing GitHub response: " + e.getMessage());
+            return -1;
+        }
+    }
+}

--- a/src/main/resources/css/about.css
+++ b/src/main/resources/css/about.css
@@ -1,0 +1,228 @@
+/* ===================================================================
+   OllamaFX - About View Styles
+   3-Block Layout: top-left (mission+donate), top-right (stats), bottom (github)
+   =================================================================== */
+
+/* ===================================================================
+   HEADER COMPACTO
+   =================================================================== */
+
+.header-app-title {
+    -fx-font-size: 26px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+}
+
+.header-version {
+    -fx-font-size: 13px;
+    -fx-text-fill: -color-fg-subtle;
+}
+
+/* ===================================================================
+   BASE CARD
+   =================================================================== */
+
+.about-card {
+    -fx-background-radius: 12px;
+    -fx-border-radius: 12px;
+    -fx-border-width: 1px;
+    -fx-border-color: -color-border-default;
+    -fx-background-color: -color-bg-subtle;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.04), 6, 0, 0, 2);
+}
+
+/* ===================================================================
+   LEFT CARD - Mission + Donations
+   =================================================================== */
+
+.card-section-title {
+    -fx-font-size: 17px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+}
+
+.card-tagline {
+    -fx-font-size: 14px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-text-fill: -color-accent-emphasis;
+}
+
+.card-body-text {
+    -fx-font-size: 14px;
+    -fx-text-fill: -color-fg-muted;
+    -fx-line-spacing: 2px;
+}
+
+.subtle-separator {
+    -fx-opacity: 0.25;
+}
+
+/* ===================================================================
+   DONATION ROWS
+   =================================================================== */
+
+.donation-row {
+    -fx-background-radius: 9px;
+    -fx-border-radius: 9px;
+    -fx-border-width: 1px;
+    -fx-cursor: hand;
+}
+
+.donation-row:hover {
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.09), 8, 0, 0, 3);
+    -fx-translate-y: -2px;
+}
+
+/* PayPal */
+.paypal-row {
+    -fx-background-color: rgba(0, 112, 186, 0.05);
+    -fx-border-color: rgba(0, 112, 186, 0.20);
+}
+
+.paypal-row:hover {
+    -fx-background-color: rgba(0, 112, 186, 0.09);
+    -fx-border-color: rgba(0, 112, 186, 0.38);
+}
+
+/* Coffee */
+.coffee-row {
+    -fx-background-color: rgba(255, 165, 0, 0.05);
+    -fx-border-color: rgba(255, 165, 0, 0.22);
+}
+
+.coffee-row:hover {
+    -fx-background-color: rgba(255, 165, 0, 0.09);
+    -fx-border-color: rgba(255, 165, 0, 0.42);
+}
+
+.donation-emoji {
+    -fx-font-size: 30px;
+}
+
+.donation-row-title {
+    -fx-font-size: 15px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+}
+
+.donation-row-subtitle {
+    -fx-font-size: 13px;
+    -fx-text-fill: -color-fg-muted;
+}
+
+/* ===================================================================
+   DONATION BUTTONS
+   =================================================================== */
+
+.donate-btn-paypal {
+    -fx-background-color: #0070ba;
+    -fx-text-fill: white;
+    -fx-background-radius: 8px;
+    -fx-padding: 9px 16px;
+    -fx-font-size: 13.5px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-cursor: hand;
+    -fx-graphic-text-gap: 8px;
+}
+
+.donate-btn-paypal:hover {
+    -fx-background-color: #005ea6;
+    -fx-effect: dropshadow(gaussian, rgba(0, 112, 186, 0.35), 8, 0, 0, 3);
+    -fx-scale-x: 1.03;
+    -fx-scale-y: 1.03;
+}
+
+.donate-btn-coffee {
+    -fx-background-color: #FFDD00;
+    -fx-text-fill: #1a1a1a;
+    -fx-background-radius: 8px;
+    -fx-padding: 9px 16px;
+    -fx-font-size: 13.5px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-cursor: hand;
+    -fx-graphic-text-gap: 8px;
+}
+
+.donate-btn-coffee:hover {
+    -fx-background-color: #FFC700;
+    -fx-effect: dropshadow(gaussian, rgba(255, 165, 0, 0.40), 8, 0, 0, 3);
+    -fx-scale-x: 1.03;
+    -fx-scale-y: 1.03;
+}
+
+/* Emoji label inside button graphic */
+.btn-icon {
+    -fx-font-size: 16px;
+}
+
+/* ===================================================================
+   RIGHT CARD - Stats
+   =================================================================== */
+
+.stats-card {
+    -fx-background-color: linear-gradient(to bottom, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.06));
+    -fx-border-color: rgba(102, 126, 234, 0.20);
+}
+
+.stats-card:hover {
+    -fx-effect: dropshadow(gaussian, rgba(102, 126, 234, 0.15), 14, 0, 0, 5);
+}
+
+.stats-big-icon {
+    -fx-font-size: 48px;
+}
+
+.stats-hero-number {
+    -fx-font-size: 56px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-text-fill: -color-accent-emphasis;
+}
+
+.stats-trust-label {
+    -fx-font-size: 16px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-text-alignment: center;
+}
+
+.stats-join-label {
+    -fx-font-size: 13px;
+    -fx-text-fill: -color-fg-muted;
+}
+
+.stats-source-label {
+    -fx-font-size: 11px;
+    -fx-text-fill: -color-fg-subtle;
+}
+
+/* ===================================================================
+   BOTTOM CARD - GitHub
+   =================================================================== */
+
+.github-big-icon {
+    -fx-font-size: 48px;
+}
+
+.github-btn {
+    -fx-background-color: transparent;
+    -fx-border-color: -color-border-default;
+    -fx-border-radius: 8px;
+    -fx-background-radius: 8px;
+    -fx-border-width: 1.5px;
+    -fx-padding: 10px 24px;
+    -fx-font-size: 14px;
+    -fx-font-weight: 500;
+    /* Removed bold */
+    -fx-cursor: hand;
+    -fx-graphic-text-gap: 8px;
+}
+
+.github-btn:hover {
+    -fx-border-color: -color-accent-emphasis;
+    -fx-text-fill: -color-accent-emphasis;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.07), 7, 0, 0, 2);
+}

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -96,6 +96,42 @@ about.poweredby=Powered by JavaFX & AtlantaFX
 about.github=GitHub Repository
 about.license=Released under MIT License
 
+# About - Mission/Storytelling
+about.mission.title=Why OllamaFX?
+about.mission.tagline=Local AI, no cloud, no compromise.
+about.mission.text=OllamaFX was born from the desire to democratize access to local LLMs. We believe everyone should have a native, lightweight, and efficient interface to run AI models without technical friction. No cloud dependencies, no privacy concerns—just pure local intelligence at your fingertips.
+
+# About - Stats
+about.stats.title=Community Impact
+about.stats.downloads=Total Downloads (GitHub)
+
+# About - Support/Donation
+about.support.title=Support Development
+about.support.text=OllamaFX is free and open-source. If you find it useful, consider supporting its development to keep it alive and evolving.
+about.button.paypal=Support via PayPal
+about.button.coffee=Buy Me a Coffee
+
+# About - Contribute
+about.contribute.title=Join the Community
+about.contribute.text=Found a bug? Have a feature idea? Want to contribute code? All contributions are welcome! Join us on GitHub to report issues, propose features, or submit Pull Requests.
+about.button.contribute=Contribute on GitHub
+
+# About - Stats/Community
+stats.community.count=people
+stats.community.trust=already trust OllamaFX
+stats.community.join=Join the community ✨
+stats.community.source=Source: GitHub Releases
+
+# About - PayPal Donation
+donate.paypal.title=Support the Project
+donate.paypal.message=Keep OllamaFX free for everyone
+donate.paypal.button=Donate via PayPal →
+
+# About - Coffee Donation
+donate.coffee.title=Buy Me a Coffee
+donate.coffee.message=A coffee helps maintain this project
+donate.coffee.button=Buy a Coffee →
+
 # Available Models View
 available.library=Library
 available.sort=Sort

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -100,6 +100,42 @@ about.poweredby=Impulsado por JavaFX & AtlantaFX
 about.github=Repositorio GitHub
 about.license=Lanzado bajo Licencia MIT
 
+# About - Misión/Storytelling
+about.mission.title=¿Por qué OllamaFX?
+about.mission.tagline=IA local, sin nube, sin compromisos.
+about.mission.text=OllamaFX nació del deseo de democratizar el acceso a LLMs locales. Creemos que todos deberían tener una interfaz nativa, ligera y eficiente para ejecutar modelos de IA sin fricciones técnicas. Sin dependencias en la nube, sin preocupaciones de privacidad—solo inteligencia local pura al alcance de tu mano.
+
+# About - Estadísticas
+about.stats.title=Impacto de la Comunidad
+about.stats.downloads=Descargas Totales (GitHub)
+
+# About - Apoyo/Donación
+about.support.title=Apoya el Desarrollo
+about.support.text=OllamaFX es gratuito y de código abierto. Si te resulta útil, considera apoyar su desarrollo para mantenerlo vivo y en evolución.
+about.button.paypal=Apoyar vía PayPal
+about.button.coffee=Cómprame un Café
+
+# About - Contribuir
+about.contribute.title=Únete a la Comunidad
+about.contribute.text=¿Encontraste un bug? ¿Tienes una idea de funcionalidad? ¿Quieres contribuir código? ¡Todas las contribuciones son bienvenidas! Únete a nosotros en GitHub para reportar issues, proponer features o enviar Pull Requests.
+about.button.contribute=Contribuir en GitHub
+
+# About - Estadísticas/Comunidad
+stats.community.count=personas
+stats.community.trust=ya confían en OllamaFX
+stats.community.join=Únete a la comunidad ✨
+stats.community.source=Fuente: GitHub Releases
+
+# About - Donación PayPal
+donate.paypal.title=Apoya el Proyecto
+donate.paypal.message=Mantén OllamaFX gratis para todos
+donate.paypal.button=Donar vía PayPal →
+
+# About - Donación Café
+donate.coffee.title=Invítame un Café
+donate.coffee.message=Un café ayuda a mantener este proyecto
+donate.coffee.button=Comprar un Café →
+
 # Available Models View
 available.library=Biblioteca
 available.sort=Ordenar

--- a/src/main/resources/ui/about_view.fxml
+++ b/src/main/resources/ui/about_view.fxml
@@ -2,49 +2,170 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.shape.SVGPath?>
-<?import javafx.scene.text.Font?>
 
-<VBox alignment="CENTER" spacing="20.0" style="-fx-background-color: transparent;" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.org.ollamafx.controller.AboutController">
-    <padding>
-        <Insets bottom="40.0" left="40.0" right="40.0" top="40.0" />
-    </padding>
+<ScrollPane fitToWidth="true" style="-fx-background-color: transparent;" stylesheets="@../css/about.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.org.ollamafx.controller.AboutController">
 
-    <!-- App Logo / Icon -->
-    <javafx.scene.image.ImageView fitHeight="128.0" fitWidth="128.0" pickOnBounds="true" preserveRatio="true">
-        <image>
-            <javafx.scene.image.Image url="@../icons/icon.png" />
-        </image>
-        <effect>
-            <javafx.scene.effect.DropShadow color="#00000040" radius="10.0" offsetY="5.0" />
-        </effect>
-    </javafx.scene.image.ImageView>
+    <VBox alignment="TOP_CENTER" spacing="0" style="-fx-background-color: transparent;">
+        <padding>
+            <Insets bottom="28" left="28" right="28" top="24" />
+        </padding>
 
-    <!-- App Name -->
-    <Label styleClass="h1" text="%app.title">
-        <font>
-            <Font name="System Bold" size="36.0" />
-        </font>
-    </Label>
-    
-    <!-- Version -->
-    <Label fx:id="versionLabel" style="-fx-text-fill: -color-fg-subtle; -fx-font-size: 14px;" text="%about.version.placeholder" />
+        <!-- ═══════════════════════════════════════════════
+             HEADER COMPACTO: Logo inline con título
+             ═══════════════════════════════════════════════ -->
+        <HBox alignment="CENTER" spacing="14">
+            <ImageView fitHeight="60" fitWidth="60" pickOnBounds="true" preserveRatio="true">
+                <image>
+                    <Image url="@../icons/icon.png" />
+                </image>
+                <effect>
+                    <javafx.scene.effect.DropShadow color="#00000028" radius="8" offsetY="3" />
+                </effect>
+            </ImageView>
+            <VBox spacing="3" alignment="CENTER_LEFT">
+                <Label styleClass="header-app-title" text="%app.title" />
+                <Label fx:id="versionLabel" styleClass="header-version" text="%about.version.placeholder" />
+            </VBox>
+        </HBox>
 
-    <!-- Description -->
-    <Label text="%about.description" styleClass="body-large" wrapText="true" textAlignment="CENTER" />
-    
-    <!-- Credits -->
-    <VBox alignment="CENTER" spacing="5.0">
-        <Label text="%about.createdby" style="-fx-text-fill: -color-fg-subtle;" />
-        <Label text="%about.poweredby" style="-fx-text-fill: -color-fg-subtle; -fx-font-size: 11px;" />
+        <Region prefHeight="20" />
+
+        <!-- ═══════════════════════════════════════════════
+             3-BLOCK GRID LAYOUT
+             ═══════════════════════════════════════════════ -->
+        <GridPane hgap="14" vgap="14">
+            <columnConstraints>
+                <ColumnConstraints percentWidth="58" />
+                <ColumnConstraints percentWidth="42" />
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints vgrow="ALWAYS" />
+                <RowConstraints />
+            </rowConstraints>
+
+            <!-- ─────────────────────────────────────────────
+                 BLOQUE SUPERIOR IZQUIERDO
+                 ───────────────────────────────────────────── -->
+            <VBox styleClass="about-card" spacing="16" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                <padding>
+                    <Insets bottom="22" left="22" right="22" top="22" />
+                </padding>
+
+                <!-- Mission -->
+                <VBox spacing="8">
+                    <Label styleClass="card-section-title" text="%about.mission.title" />
+                    <Label styleClass="card-tagline" text="%about.mission.tagline" />
+                    <Label styleClass="card-body-text" text="%about.mission.text" wrapText="true" />
+                </VBox>
+
+                <Separator styleClass="subtle-separator" />
+
+                <!-- Support / Donation -->
+                <VBox spacing="12">
+                    <Label styleClass="card-section-title" text="%about.support.title" />
+
+                    <!-- PayPal Row -->
+                    <HBox styleClass="donation-row, paypal-row" spacing="14" alignment="CENTER_LEFT">
+                        <padding>
+                            <Insets bottom="14" left="16" right="16" top="14" />
+                        </padding>
+                        <Label styleClass="donation-emoji" text="💙" />
+                        <VBox spacing="2" HBox.hgrow="ALWAYS">
+                            <Label styleClass="donation-row-title" text="%donate.paypal.title" />
+                            <Label styleClass="donation-row-subtitle" text="%donate.paypal.message" wrapText="true" />
+                        </VBox>
+                        <Button fx:id="paypalButton" onAction="#openPayPal" styleClass="donate-btn-paypal" minWidth="145" text="%donate.paypal.button" />
+                    </HBox>
+
+                    <!-- Coffee Row -->
+                    <HBox styleClass="donation-row, coffee-row" spacing="14" alignment="CENTER_LEFT">
+                        <padding>
+                            <Insets bottom="14" left="16" right="16" top="14" />
+                        </padding>
+                        <Label styleClass="donation-emoji" text="☕" />
+                        <VBox spacing="2" HBox.hgrow="ALWAYS">
+                            <Label styleClass="donation-row-title" text="%donate.coffee.title" />
+                            <Label styleClass="donation-row-subtitle" text="%donate.coffee.message" wrapText="true" />
+                        </VBox>
+                        <Button fx:id="coffeeButton" onAction="#openBuyMeCoffee" styleClass="donate-btn-coffee" minWidth="145" text="%donate.coffee.button" />
+                    </HBox>
+                </VBox>
+
+            </VBox>
+
+            <!-- ─────────────────────────────────────────────
+                 BLOQUE SUPERIOR DERECHO - Stats
+                 ───────────────────────────────────────────── -->
+            <VBox styleClass="about-card, stats-card" spacing="0" alignment="CENTER" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                <padding>
+                    <Insets bottom="24" left="20" right="20" top="28" />
+                </padding>
+
+                <Label styleClass="stats-big-icon" text="👥" />
+                <Region prefHeight="14" />
+
+                <ProgressIndicator fx:id="downloadSpinner" prefHeight="26" prefWidth="26" />
+                <Region prefHeight="8" />
+
+                <Label fx:id="downloadsLabel" styleClass="stats-hero-number" text="..." />
+                <Region prefHeight="10" />
+
+                <Label styleClass="stats-trust-label" text="%stats.community.trust" />
+                <Region prefHeight="5" />
+                <Label styleClass="stats-join-label" text="%stats.community.join" />
+
+                <Region VBox.vgrow="ALWAYS" />
+
+                <Separator opacity="0.15" maxWidth="100" />
+                <Region prefHeight="10" />
+                <Label styleClass="stats-source-label" text="%stats.community.source" />
+
+            </VBox>
+
+            <!-- ─────────────────────────────────────────────
+                 BLOQUE INFERIOR - GitHub Centrado Vertical
+                 ───────────────────────────────────────────── -->
+            <VBox styleClass="about-card" spacing="16" alignment="CENTER" GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="2">
+                <padding>
+                    <Insets bottom="28" left="24" right="24" top="28" />
+                </padding>
+
+                <Label styleClass="github-big-icon" text="🐙" />
+
+                <VBox spacing="6" alignment="CENTER">
+                    <Label styleClass="card-section-title" text="%about.contribute.title" />
+                    <Label styleClass="card-body-text" text="%about.contribute.text" wrapText="true" textAlignment="CENTER" maxWidth="700" />
+                </VBox>
+
+                <Region prefHeight="8" />
+
+                <Button fx:id="githubButton" onAction="#openGitHubContribute" styleClass="github-btn" minWidth="180" text="%about.button.contribute" />
+            </VBox>
+
+        </GridPane>
+
+        <Region prefHeight="20" />
+
+        <!-- FOOTER -->
+        <VBox alignment="CENTER" spacing="3" style="-fx-opacity: 0.40;">
+            <Label text="%about.createdby" style="-fx-font-size: 12px;" />
+            <Label text="%about.poweredby" style="-fx-font-size: 11px;" />
+            <Label text="%about.license" style="-fx-font-size: 11px;" />
+        </VBox>
+
+        <Region prefHeight="12" />
+
     </VBox>
-
-    <!-- Links -->
-    <Hyperlink onAction="#openGitHub" text="%about.github" style="-fx-font-size: 14px;" />
-    
-    <Label text="%about.license" style="-fx-text-fill: -color-fg-subtle; -fx-font-size: 10px;" />
-
-</VBox>
+</ScrollPane>


### PR DESCRIPTION
Revamp the About screen and add telemetry/support features:

- Bump Java toolchain to Java 21 in build.gradle.
- App.java: store HostServices and expose getAppHostServices() so UI can open external links.
- New GitHubStatsService: async HTTP + Jackson-based service to fetch GitHub release asset download counts.
- AboutController: integrate GitHubStatsService, add donation buttons (PayPal / BuyMeACoffee), progress indicator, emoji icons, and use HostServices to open links.
- New about.css styling for the redesigned layout and controls.
- Fully redesigned about_view.fxml: 3-block layout (mission/donations, stats, GitHub/contribute), wired controls and localized text keys.
- Extended localization (messages_en.properties and messages_es.properties) with mission, stats, donation and contribute strings.

Notes: the new service uses com.fasterxml.jackson for JSON parsing and java.net.http.HttpClient; ensure Jackson is available on the classpath if not already included.