### PR TITLE
fix: the issue 89 has been resolved

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.org.ollamafx'
-version = '0.5.0'
+version = '0.5.1'
 
 repositories {
     mavenCentral()
@@ -82,7 +82,6 @@ javafx {
 
 application {
     mainClass = 'com.org.ollamafx.Main'
-    applicationDefaultJvmArgs = ['-Xdock:name=OllamaFX', '-Xdock:icon=src/main/resources/icons/icon.png']
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
remove JDK parameters in Gradle File because cause fail on start in Linux Ubuntu, this bug was reported in issue 89

https://github.com/fredericksalazar/OllamaFX/issues/89